### PR TITLE
refactor: extract left menu subcomponents

### DIFF
--- a/src/left-menu/FilterCombo.tsx
+++ b/src/left-menu/FilterCombo.tsx
@@ -1,0 +1,247 @@
+import * as React from "react";
+
+export type FilterComboOption = { id: string; label: string };
+
+type FilterComboProps = {
+  label: string;
+  placeholder: string;
+  query: string;
+  setQuery: (v: string) => void;
+  options: FilterComboOption[];
+  selected: FilterComboOption[];
+  onAdd: (item: FilterComboOption) => void;
+  onRemove: (idx: number) => void;
+  stop: (e: React.SyntheticEvent) => void;
+  inputStyle: React.CSSProperties;
+  dropdownStyle: React.CSSProperties;
+  dropdownItem: React.CSSProperties;
+  chipStyle: React.CSSProperties;
+  chipsRowStyle: React.CSSProperties;
+};
+
+export const FilterCombo: React.FC<FilterComboProps> = ({
+  label,
+  placeholder,
+  query,
+  setQuery,
+  options,
+  selected,
+  onAdd,
+  onRemove,
+  stop,
+  inputStyle,
+  dropdownStyle,
+  dropdownItem,
+  chipStyle,
+  chipsRowStyle,
+}) => {
+  const [open, setOpen] = React.useState(false);
+  return (
+    <div style={{ width: (inputStyle.width as number) || undefined }}>
+      <div style={{ fontSize: 12, color: "#4b5563", marginBottom: 4 }}>{label}</div>
+      <div style={{ display: "grid", gap: 8 }}>
+        <div style={chipsRowStyle}>
+          {selected.map((s, i) => (
+            <span key={s.id} style={chipStyle}>
+              {s.label}
+              <button
+                aria-label="Remove"
+                onMouseDown={stop}
+                onClick={() => onRemove(i)}
+                style={{ border: "none", background: "transparent", cursor: "pointer", color: "#6b7280" }}
+              >
+                ×
+              </button>
+            </span>
+          ))}
+        </div>
+        <div style={{ position: "relative" }}>
+          <input
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            onFocus={() => setOpen(true)}
+            onBlur={() => setTimeout(() => setOpen(false), 120)}
+            placeholder={placeholder}
+            onMouseDown={stop}
+            style={inputStyle}
+          />
+          {open && options.length > 0 && (
+            <div style={{ ...dropdownStyle, top: 40 }}>
+              {options.map((opt) => (
+                <div
+                  key={opt.id}
+                  style={dropdownItem}
+                  onMouseDown={stop}
+                  onClick={() => onAdd(opt)}
+                >
+                  {opt.label}
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+type CategoryComboProps = {
+  label: string;
+  placeholder: string;
+  options: string[];
+  selected: string[];
+  onAdd: (item: string) => void;
+  onRemove: (idx: number) => void;
+  stop: (e: React.SyntheticEvent) => void;
+  inputStyle: React.CSSProperties;
+  dropdownStyle: React.CSSProperties;
+  dropdownItem: React.CSSProperties;
+  chipStyle: React.CSSProperties;
+  chipsRowStyle: React.CSSProperties;
+};
+
+export const CategoryCombo: React.FC<CategoryComboProps> = ({
+  label,
+  placeholder,
+  options,
+  selected,
+  onAdd,
+  onRemove,
+  stop,
+  inputStyle,
+  dropdownStyle,
+  dropdownItem,
+  chipStyle,
+  chipsRowStyle,
+}) => {
+  const [q, setQ] = React.useState("");
+  const [open, setOpen] = React.useState(false);
+  const filtered = options.filter(o => o.toLowerCase().startsWith(q.toLowerCase()));
+  return (
+    <div style={{ width: (inputStyle.width as number) || undefined }}>
+      <div style={{ fontSize: 12, color: "#4b5563", marginBottom: 4 }}>{label}</div>
+      <div style={{ display: "grid", gap: 8 }}>
+        <div style={chipsRowStyle}>
+          {selected.map((s, i) => (
+            <span key={`${s}-${i}`} style={chipStyle}>
+              {s}
+              <button
+                aria-label="Remove"
+                onMouseDown={stop}
+                onClick={() => onRemove(i)}
+                style={{ border: "none", background: "transparent", cursor: "pointer", color: "#6b7280" }}
+              >
+                ×
+              </button>
+            </span>
+          ))}
+        </div>
+        <div style={{ position: "relative" }}>
+          <input
+            value={q}
+            onChange={(e) => setQ(e.target.value)}
+            onFocus={() => setOpen(true)}
+            onBlur={() => setTimeout(() => setOpen(false), 120)}
+            placeholder={placeholder}
+            onMouseDown={stop}
+            style={inputStyle}
+          />
+          {open && filtered.length > 0 && (
+            <div style={{ ...dropdownStyle, top: 40 }}>
+              {filtered.map((opt) => (
+                <div
+                  key={opt}
+                  style={dropdownItem}
+                  onMouseDown={stop}
+                  onClick={() => onAdd(opt)}
+                >
+                  {opt}
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+type SingleComboProps = {
+  label: string;
+  placeholder: string;
+  query: string;
+  setQuery: (v: string) => void;
+  options: FilterComboOption[];
+  selected: FilterComboOption | null;
+  onSelect: (v: FilterComboOption | null) => void;
+  stop: (e: React.SyntheticEvent) => void;
+  inputStyle: React.CSSProperties;
+  dropdownStyle: React.CSSProperties;
+  dropdownItem: React.CSSProperties;
+  chipStyle: React.CSSProperties;
+  width: number;
+};
+
+export const SingleCombo: React.FC<SingleComboProps> = ({
+  label,
+  placeholder,
+  query,
+  setQuery,
+  options,
+  selected,
+  onSelect,
+  stop,
+  inputStyle,
+  dropdownStyle,
+  dropdownItem,
+  chipStyle,
+  width,
+}) => {
+  const [open, setOpen] = React.useState(false);
+  return (
+    <div style={{ width }}>
+      <div style={{ fontSize: 12, color: "#4b5563", marginBottom: 4 }}>{label}</div>
+      <div style={{ display: "grid", gap: 8 }}>
+        {selected && (
+          <span style={chipStyle}>
+            {selected.label}
+            <button
+              aria-label="Remove"
+              onMouseDown={stop}
+              onClick={() => onSelect(null)}
+              style={{ border: "none", background: "transparent", cursor: "pointer", color: "#6b7280" }}
+            >
+              ×
+            </button>
+          </span>
+        )}
+        <div style={{ position: "relative" }}>
+          <input
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            onFocus={() => setOpen(true)}
+            onBlur={() => setTimeout(() => setOpen(false), 120)}
+            placeholder={placeholder}
+            onMouseDown={stop}
+            style={inputStyle}
+          />
+          {open && options.length > 0 && (
+            <div style={{ ...dropdownStyle, top: 40 }}>
+              {options.map((opt) => (
+                <div
+                  key={opt.id}
+                  style={dropdownItem}
+                  onMouseDown={stop}
+                  onClick={() => onSelect(opt)}
+                >
+                  {opt.label}
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+

--- a/src/left-menu/LayoutControls.tsx
+++ b/src/left-menu/LayoutControls.tsx
@@ -1,0 +1,203 @@
+import * as React from "react";
+import * as RadioGroup from "@radix-ui/react-radio-group";
+
+const PALETTES = [
+  { v: "minimal-gray", label: "Minimalistic gray", swatch: ["#f3f4f6", "#d1d5db", "#9ca3af"] },
+  { v: "green-forest", label: "Green forest", swatch: ["#064e3b", "#10b981", "#a7f3d0"] },
+  { v: "ocean-blue", label: "Ocean blue", swatch: ["#0ea5e9", "#0369a1", "#e0f2fe"] },
+  { v: "sunset", label: "Sunset", swatch: ["#fb7185", "#f59e0b", "#fde68a"] },
+  { v: "candy-pop", label: "Candy pop", swatch: ["#e879f9", "#60a5fa", "#fca5a5"] },
+  { v: "monochrome", label: "Monochrome", swatch: ["#111827", "#6b7280", "#e5e7eb"] },
+  { v: "pastel-field", label: "Pastel field", swatch: ["#a7f3d0", "#fbcfe8", "#bfdbfe"] },
+];
+
+const paletteLabel = (v: string) => {
+  const p = PALETTES.find((x) => x.v === v);
+  return p ? p.label : v;
+};
+
+export const LayoutControls: React.FC = () => {
+  const [layoutMode, setLayoutMode] = React.useState("mindmap1");
+  const [palette, setPalette] = React.useState("minimal-gray");
+  const [palettesOpen, setPalettesOpen] = React.useState(false);
+
+  const stop = (e: React.SyntheticEvent) => e.stopPropagation();
+
+  const FIELD_W = 200;
+
+  const sectionTitle: React.CSSProperties = {
+    fontSize: 12,
+    fontWeight: 700,
+    color: "#374151",
+    textTransform: "uppercase",
+    letterSpacing: 0.4,
+    margin: "4px 0 8px",
+  };
+  const group: React.CSSProperties = { display: "grid", gap: 8 };
+  const labelStyle: React.CSSProperties = {
+    fontSize: 12,
+    color: "#4b5563",
+    marginBottom: 4,
+  };
+  const radioRowStyle: React.CSSProperties = {
+    display: "flex",
+    alignItems: "center",
+    gap: 10,
+    padding: "8px 10px",
+    background: "#fff",
+    border: "1px solid #e5e7eb",
+    borderRadius: 10,
+    cursor: "pointer",
+  };
+  const radioOuterStyle: React.CSSProperties = {
+    width: 18,
+    height: 18,
+    borderRadius: "50%",
+    border: "1px solid #c7cdd6",
+    background: "#fff",
+    display: "grid",
+    placeItems: "center",
+  };
+  const radioDotStyle: React.CSSProperties = {
+    width: 10,
+    height: 10,
+    borderRadius: "50%",
+    background: "#111827",
+  };
+  const selectBoxNarrow: React.CSSProperties = {
+    width: FIELD_W,
+    height: 34,
+    borderRadius: 10,
+    border: "1px solid #e5e7eb",
+    background: "#ffffff",
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "space-between",
+    padding: "0 10px",
+    fontSize: 13,
+    color: "#111827",
+    cursor: "pointer",
+  };
+
+  return (
+    <div>
+      <div style={sectionTitle}>Map layout</div>
+      <div style={group}>
+        {/* Layout mode */}
+        <div>
+          <div style={labelStyle}>Layout mode</div>
+          <RadioGroup.Root
+            value={layoutMode}
+            onValueChange={setLayoutMode}
+            onMouseDown={stop}
+            style={{ display: "grid", gap: 8, width: FIELD_W }}
+          >
+            {[
+              { v: "mindmap1", label: "Mind map 1" },
+              { v: "hierarchy", label: "Hierarchy" },
+            ].map((o) => (
+              <label key={o.v} style={radioRowStyle}>
+                <RadioGroup.Item value={o.v} style={radioOuterStyle}>
+                  <RadioGroup.Indicator style={radioDotStyle} />
+                </RadioGroup.Item>
+                <span style={{ fontSize: 13, color: "#111827" }}>{o.label}</span>
+              </label>
+            ))}
+          </RadioGroup.Root>
+        </div>
+
+        {/* Layout palettes (collapsible to save space) */}
+        <div>
+          <div
+            style={{
+              ...labelStyle,
+              marginBottom: 6,
+              display: "flex",
+              alignItems: "center",
+              gap: 8,
+            }}
+          >
+            <button
+              onMouseDown={stop}
+              onClick={() => setPalettesOpen((v) => !v)}
+              style={{
+                ...selectBoxNarrow,
+                width: FIELD_W,
+                justifyContent: "space-between",
+                background: "#fff",
+              }}
+            >
+              <span style={{ display: "inline-flex", alignItems: "center", gap: 8 }}>
+                <strong style={{ fontWeight: 600 }}>Layout palettes</strong>
+                <span style={{ fontSize: 12, color: "#6b7280" }}>
+                  {paletteLabel(palette)}
+                </span>
+              </span>
+              <svg
+                width="14"
+                height="14"
+                viewBox="0 0 24 24"
+                fill="none"
+                style={{
+                  transform: palettesOpen ? "rotate(180deg)" : "rotate(0)",
+                  transition: "transform 160ms ease",
+                }}
+              >
+                <path
+                  d="M7 10l5 5 5-5"
+                  stroke="#6b7280"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+              </svg>
+            </button>
+          </div>
+
+          {palettesOpen && (
+            <RadioGroup.Root
+              value={palette}
+              onValueChange={setPalette}
+              onMouseDown={stop}
+              style={{ display: "grid", gap: 8, width: FIELD_W, marginTop: 6 }}
+            >
+              {PALETTES.map((o) => (
+                <label key={o.v} style={radioRowStyle}>
+                  <RadioGroup.Item value={o.v} style={radioOuterStyle}>
+                    <RadioGroup.Indicator style={radioDotStyle} />
+                  </RadioGroup.Item>
+                  <span
+                    style={{
+                      fontSize: 13,
+                      color: "#111827",
+                      display: "inline-flex",
+                      alignItems: "center",
+                      gap: 8,
+                    }}
+                  >
+                    {o.label}
+                    <span style={{ display: "inline-flex", gap: 4 }}>
+                      {o.swatch.map((c, i) => (
+                        <span
+                          key={i}
+                          style={{
+                            width: 12,
+                            height: 12,
+                            borderRadius: 4,
+                            background: c,
+                            border: "1px solid #e5e7eb",
+                          }}
+                        />
+                      ))}
+                    </span>
+                  </span>
+                </label>
+              ))}
+            </RadioGroup.Root>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+

--- a/src/left-menu/LeftMenu.tsx
+++ b/src/left-menu/LeftMenu.tsx
@@ -1,7 +1,13 @@
 import * as React from "react";
 import { motion } from "framer-motion";
 import * as Switch from "@radix-ui/react-switch";
-import * as RadioGroup from "@radix-ui/react-radio-group";
+
+import { MapViewControls } from "./MapViewControls";
+import { LayoutControls } from "./LayoutControls";
+
+export { MapViewControls } from "./MapViewControls";
+export { LayoutControls } from "./LayoutControls";
+export { FilterCombo, CategoryCombo, SingleCombo } from "./FilterCombo";
 
 import rawData from "../notion_data.json";
 import { parse } from "../data/parse";
@@ -27,7 +33,7 @@ export const LeftMenu: React.FC<LeftMenuProps> = ({
   const { byId, children, roots } = React.useMemo(() => parse(data), [data]);
   const root = roots[0];
 
-  const { depths, maxDepth } = React.useMemo(() => {
+  const { maxDepth } = React.useMemo(() => {
     const d = new Map<string, number>();
     let max = 1;
     const q: string[] = [];
@@ -39,7 +45,7 @@ export const LeftMenu: React.FC<LeftMenuProps> = ({
         if (!d.has(ch.id)) { const nd = pd + 1; d.set(ch.id, nd); max = Math.max(max, nd); q.push(ch.id); }
       });
     }
-    return { depths: d, maxDepth: Math.max(1, max + 1) };
+    return { maxDepth: Math.max(1, max + 1) };
   }, [root, children]);
 
   const nodeOptions: { id: string; label: string }[] = React.useMemo(() => {
@@ -77,35 +83,8 @@ export const LeftMenu: React.FC<LeftMenuProps> = ({
   // ---------- local UI state (visual only) ----------
   const [darkMode, setDarkMode] = React.useState(false);
 
-  // Map View
-  const [expandMode, setExpandMode] = React.useState<"expand" | "collapse">("expand");
-  const [levelShown, setLevelShown] = React.useState<number>(Math.min(3, Math.max(1, maxDepth)));
-  const [levelsOpen, setLevelsOpen] = React.useState(false);
-
-  const [showOnlyQuery, setShowOnlyQuery] = React.useState("");
-  const [excludeQuery, setExcludeQuery] = React.useState("");
-  const [centerQuery, setCenterQuery] = React.useState("");
-
-  const [showOnlySel, setShowOnlySel] = React.useState<{ id: string; label: string }[]>([]);
-  const [excludeSel, setExcludeSel] = React.useState<{ id: string; label: string }[]>([]);
-  const [categoryOnlySel, setCategoryOnlySel] = React.useState<string[]>([]);
-  const [categoryExcludeSel, setCategoryExcludeSel] = React.useState<string[]>([]);
-  const [centerSel, setCenterSel] = React.useState<{ id: string; label: string } | null>(null);
-
-  // Map layout
-  const [layoutMode, setLayoutMode] = React.useState("mindmap1");
-  const [palette, setPalette] = React.useState("minimal-gray");
-  const [palettesOpen, setPalettesOpen] = React.useState(false); // collapsible to save space
-
   // ---------- helpers ----------
   const stop = (e: React.SyntheticEvent) => e.stopPropagation();
-  const filteredNodes = (q: string) =>
-    nodeOptions.filter(o => o.label.toLowerCase().startsWith(q.trim().toLowerCase()));
-  const filteredCats = (q: string) =>
-    categoryOptions.filter(c => c.toLowerCase().startsWith(q.trim().toLowerCase()));
-  const addUnique = <T,>(arr: T[], item: T, eq: (a: T, b: T) => boolean) =>
-    arr.find(x => eq(x, item)) ? arr : [...arr, item];
-  const removeAt = <T,>(arr: T[], index: number) => arr.filter((_, i) => i !== index);
 
   // ---------- styles ----------
   const FIELD_W = 200; // compact width for Level + all filters below
@@ -187,103 +166,7 @@ export const LeftMenu: React.FC<LeftMenuProps> = ({
     margin: "4px 0 8px",
   };
 
-  const group: React.CSSProperties = { display: "grid", gap: 8 };
-  const labelStyle: React.CSSProperties = { fontSize: 12, color: "#4b5563", marginBottom: 4 };
   const divider: React.CSSProperties = { height: 1, background: "#e5e7eb", margin: "10px 0" };
-
-  const chip: React.CSSProperties = {
-    display: "inline-flex",
-    alignItems: "center",
-    gap: 6,
-    padding: "4px 8px",
-    background: "#fff",
-    border: "1px solid #e5e7eb",
-    borderRadius: 999,
-    fontSize: 12,
-    color: "#111827",
-  };
-
-  // compact fields
-  const inputNarrow: React.CSSProperties = {
-    width: FIELD_W,
-    height: 34,
-    padding: "0 10px",
-    borderRadius: 10,
-    border: "1px solid #e5e7eb",
-    background: "#ffffff",
-    outline: "none",
-    fontSize: 13,
-    color: "#111827",
-  };
-
-  const chipsRowNarrow: React.CSSProperties = {
-    display: "flex",
-    gap: 6,
-    flexWrap: "wrap",
-    maxWidth: FIELD_W,
-  };
-
-  const listBox: React.CSSProperties = { position: "relative" };
-
-  const dropdownNarrow: React.CSSProperties = {
-    position: "absolute",
-    top: 6,
-    left: 0,
-    width: FIELD_W,
-    maxHeight: 160,
-    overflow: "auto",
-    background: "#fff",
-    border: "1px solid #e5e7eb",
-    borderRadius: 10,
-    boxShadow: "0 8px 20px rgba(0,0,0,0.08)",
-    zIndex: 30,
-  };
-
-  const dropdownItem: React.CSSProperties = {
-    padding: "8px 10px",
-    fontSize: 13,
-    color: "#111827",
-    cursor: "pointer",
-    borderBottom: "1px solid #f3f4f6",
-  };
-
-  const segWrap: React.CSSProperties = { display: "grid", gridTemplateColumns: "1fr 1fr", gap: 8 };
-  const segBtn = (active: boolean): React.CSSProperties => ({
-    height: 34,
-    borderRadius: 10,
-    border: "1px solid #e5e7eb",
-    background: active ? "#111827" : "#ffffff",
-    color: active ? "#ffffff" : "#111827",
-    fontSize: 13,
-    cursor: "pointer",
-  });
-
-  const selectBoxNarrow: React.CSSProperties = {
-    width: FIELD_W,
-    height: 34,
-    borderRadius: 10,
-    border: "1px solid #e5e7eb",
-    background: "#ffffff",
-    display: "flex",
-    alignItems: "center",
-    justifyContent: "space-between",
-    padding: "0 10px",
-    fontSize: 13,
-    color: "#111827",
-    cursor: "pointer",
-  };
-
-  const resetBtn: React.CSSProperties = {
-    width: FIELD_W,
-    height: 36,
-    borderRadius: 12,
-    border: "1px solid #e5e7eb",
-    background: "#ffffff",
-    color: "#111827",
-    fontSize: 13,
-    fontWeight: 600,
-    cursor: "pointer",
-  };
 
   const linkBtn: React.CSSProperties = {
     height: 34,
@@ -387,218 +270,24 @@ export const LeftMenu: React.FC<LeftMenuProps> = ({
         </div>
 
         {/* Content */}
-        <div style={{ padding: 14, height: "calc(100% - 58px)", display: "flex", flexDirection: "column", gap: 12 }}>
-          {/* MAP VIEW */}
-          <div>
-            <div style={sectionTitle}>Map View</div>
-            <div style={group}>
-              {/* Expand / Collapse */}
-              <div>
-                <div style={labelStyle}>Expand</div>
-                <div style={{ ...segWrap, width: FIELD_W }}>
-                  <button style={segBtn(expandMode === "expand")} onMouseDown={stop} onClick={() => setExpandMode("expand")}>Expand all</button>
-                  <button style={segBtn(expandMode === "collapse")} onMouseDown={stop} onClick={() => setExpandMode("collapse")}>Collapse all</button>
-                </div>
-              </div>
-
-              {/* Show levels */}
-              <div>
-                <div style={labelStyle}>Show levels</div>
-                <div style={{ position: "relative", width: FIELD_W }}>
-                  <div style={selectBoxNarrow} onMouseDown={stop} onClick={() => setLevelsOpen(v => !v)}>
-                    <span>Level {levelShown}</span>
-                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none">
-                      <path d="M7 10l5 5 5-5" stroke="#6b7280" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
-                    </svg>
-                  </div>
-                  {levelsOpen && (
-                    <div style={{ ...dropdownNarrow, top: 40 }}>
-                      {Array.from({ length: Math.max(1, maxDepth) }, (_, i) => i + 1).map((lvl) => (
-                        <div
-                          key={lvl}
-                          style={{ ...dropdownItem, background: lvl === levelShown ? "#f3f4f6" : "#fff" }}
-                          onMouseDown={stop}
-                          onClick={() => { setLevelShown(lvl); setLevelsOpen(false); }}
-                        >
-                          Level {lvl}
-                        </div>
-                      ))}
-                    </div>
-                  )}
-                </div>
-              </div>
-
-              {/* Show only filter */}
-              <ComboWithChips
-                label="Show only filter"
-                placeholder="Type to search nodes…"
-                query={showOnlyQuery}
-                setQuery={setShowOnlyQuery}
-                options={filteredNodes(showOnlyQuery)}
-                selected={showOnlySel}
-                onAdd={(item) => setShowOnlySel(prev => addUnique(prev, item, (a, b) => a.id === b.id))}
-                onRemove={(idx) => setShowOnlySel(prev => removeAt(prev, idx))}
-                stop={stop}
-                inputStyle={inputNarrow}
-                dropdownStyle={dropdownNarrow}
-                dropdownItem={dropdownItem}
-                chipStyle={chip}
-                chipsRowStyle={chipsRowNarrow}
-              />
-
-              {/* Exclude filter */}
-              <ComboWithChips
-                label="Exclude filter"
-                placeholder="Type to search nodes…"
-                query={excludeQuery}
-                setQuery={setExcludeQuery}
-                options={filteredNodes(excludeQuery)}
-                selected={excludeSel}
-                onAdd={(item) => setExcludeSel(prev => addUnique(prev, item, (a, b) => a.id === b.id))}
-                onRemove={(idx) => setExcludeSel(prev => removeAt(prev, idx))}
-                stop={stop}
-                inputStyle={inputNarrow}
-                dropdownStyle={dropdownNarrow}
-                dropdownItem={dropdownItem}
-                chipStyle={chip}
-                chipsRowStyle={chipsRowNarrow}
-              />
-
-              {/* Show only categories */}
-              <ComboCats
-                label="Show only categories"
-                placeholder="Type to search categories…"
-                options={filteredCats("")}
-                selected={categoryOnlySel}
-                onAdd={(item) => setCategoryOnlySel(prev => addUnique(prev, item, (a,b)=>a===b))}
-                onRemove={(idx) => setCategoryOnlySel(prev => removeAt(prev, idx))}
-                stop={stop}
-                inputStyle={inputNarrow}
-                dropdownStyle={dropdownNarrow}
-                dropdownItem={dropdownItem}
-                chipStyle={chip}
-                chipsRowStyle={chipsRowNarrow}
-              />
-
-              {/* Exclude categories */}
-              <ComboCats
-                label="Exclude categories"
-                placeholder="Type to search categories…"
-                options={filteredCats("")}
-                selected={categoryExcludeSel}
-                onAdd={(item) => setCategoryExcludeSel(prev => addUnique(prev, item, (a,b)=>a===b))}
-                onRemove={(idx) => setCategoryExcludeSel(prev => removeAt(prev, idx))}
-                stop={stop}
-                inputStyle={inputNarrow}
-                dropdownStyle={dropdownNarrow}
-                dropdownItem={dropdownItem}
-                chipStyle={chip}
-                chipsRowStyle={chipsRowNarrow}
-              />
-
-              {/* Center view */}
-              <SingleCombo
-                label="Center view"
-                placeholder="Type to search nodes…"
-                query={centerQuery}
-                setQuery={setCenterQuery}
-                options={filteredNodes(centerQuery)}
-                selected={centerSel}
-                onSelect={setCenterSel}
-                stop={stop}
-                inputStyle={inputNarrow}
-                dropdownStyle={dropdownNarrow}
-                dropdownItem={dropdownItem}
-                chipStyle={chip}
-                width={FIELD_W}
-              />
-
-              {/* Reset Layout */}
-              <button style={resetBtn} onMouseDown={stop}>Reset Layout</button>
-            </div>
-          </div>
+        <div
+          style={{
+            padding: 14,
+            height: "calc(100% - 58px)",
+            display: "flex",
+            flexDirection: "column",
+            gap: 12,
+          }}
+        >
+          <MapViewControls
+            nodeOptions={nodeOptions}
+            categoryOptions={categoryOptions}
+            maxDepth={maxDepth}
+          />
 
           <div style={divider} />
 
-          {/* MAP LAYOUT */}
-          <div>
-            <div style={sectionTitle}>Map layout</div>
-            <div style={group}>
-              {/* Layout mode */}
-              <div>
-                <div style={labelStyle}>Layout mode</div>
-                <RadioGroup.Root
-                  value={layoutMode}
-                  onValueChange={setLayoutMode}
-                  onMouseDown={stop}
-                  style={{ display: "grid", gap: 8, width: FIELD_W }}
-                >
-                  {[
-                    { v: "mindmap1", label: "Mind map 1" },
-                    { v: "hierarchy", label: "Hierarchy" },
-                  ].map(o => (
-                    <label key={o.v} style={radioRowStyle}>
-                      <RadioGroup.Item value={o.v} style={radioOuterStyle}>
-                        <RadioGroup.Indicator style={radioDotStyle} />
-                      </RadioGroup.Item>
-                      <span style={{ fontSize: 13, color: "#111827" }}>{o.label}</span>
-                    </label>
-                  ))}
-                </RadioGroup.Root>
-              </div>
-
-              {/* Layout palettes (collapsible to save space) */}
-              <div>
-                <div style={{ ...labelStyle, marginBottom: 6, display: "flex", alignItems: "center", gap: 8 }}>
-                  <button
-                    onMouseDown={stop}
-                    onClick={() => setPalettesOpen(v => !v)}
-                    style={{
-                      ...selectBoxNarrow,
-                      width: FIELD_W,
-                      justifyContent: "space-between",
-                      background: "#fff",
-                    }}
-                  >
-                    <span style={{ display: "inline-flex", alignItems: "center", gap: 8 }}>
-                      <strong style={{ fontWeight: 600 }}>Layout palettes</strong>
-                      <span style={{ fontSize: 12, color: "#6b7280" }}>
-                        {paletteLabel(palette)}
-                      </span>
-                    </span>
-                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" style={{ transform: palettesOpen ? "rotate(180deg)" : "rotate(0)", transition: "transform 160ms ease" }}>
-                      <path d="M7 10l5 5 5-5" stroke="#6b7280" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
-                    </svg>
-                  </button>
-                </div>
-
-                {palettesOpen && (
-                  <RadioGroup.Root
-                    value={palette}
-                    onValueChange={setPalette}
-                    onMouseDown={stop}
-                    style={{ display: "grid", gap: 8, width: FIELD_W, marginTop: 6 }}
-                  >
-                    {PALETTES.map(o => (
-                      <label key={o.v} style={radioRowStyle}>
-                        <RadioGroup.Item value={o.v} style={radioOuterStyle}>
-                          <RadioGroup.Indicator style={radioDotStyle} />
-                        </RadioGroup.Item>
-                        <span style={{ fontSize: 13, color: "#111827", display: "inline-flex", alignItems: "center", gap: 8 }}>
-                          {o.label}
-                          <span style={{ display: "inline-flex", gap: 4 }}>
-                            {o.swatch.map((c, i) => (
-                              <span key={i} style={{ width: 12, height: 12, borderRadius: 4, background: c, border: "1px solid #e5e7eb" }} />
-                            ))}
-                          </span>
-                        </span>
-                      </label>
-                    ))}
-                  </RadioGroup.Root>
-                )}
-              </div>
-            </div>
-          </div>
+          <LayoutControls />
 
           <div style={divider} />
 
@@ -606,9 +295,15 @@ export const LeftMenu: React.FC<LeftMenuProps> = ({
           <div>
             <div style={sectionTitle}>More</div>
             <div style={{ display: "grid", gap: 8, width: FIELD_W }}>
-              <button style={linkBtn} onMouseDown={stop}>Quick tutorial</button>
-              <button style={linkBtn} onMouseDown={stop}>Manage Connections</button>
-              <button style={linkBtn} onMouseDown={stop}>Configuration</button>
+              <button style={linkBtn} onMouseDown={stop}>
+                Quick tutorial
+              </button>
+              <button style={linkBtn} onMouseDown={stop}>
+                Manage Connections
+              </button>
+              <button style={linkBtn} onMouseDown={stop}>
+                Configuration
+              </button>
             </div>
           </div>
 
@@ -618,260 +313,5 @@ export const LeftMenu: React.FC<LeftMenuProps> = ({
         </div>
       </motion.div>
     </>
-  );
-};
-
-// ---------- palettes ----------
-const PALETTES = [
-  { v: "minimal-gray", label: "Minimalistic gray", swatch: ["#f3f4f6","#d1d5db","#9ca3af"] },
-  { v: "green-forest", label: "Green forest", swatch: ["#064e3b","#10b981","#a7f3d0"] },
-  { v: "ocean-blue", label: "Ocean blue", swatch: ["#0ea5e9","#0369a1","#e0f2fe"] },
-  { v: "sunset", label: "Sunset", swatch: ["#fb7185","#f59e0b","#fde68a"] },
-  { v: "candy-pop", label: "Candy pop", swatch: ["#e879f9","#60a5fa","#fca5a5"] },
-  { v: "monochrome", label: "Monochrome", swatch: ["#111827","#6b7280","#e5e7eb"] },
-  { v: "pastel-field", label: "Pastel field", swatch: ["#a7f3d0","#fbcfe8","#bfdbfe"] },
-];
-
-const paletteLabel = (v: string) => {
-  const p = PALETTES.find(x => x.v === v);
-  return p ? p.label : v;
-};
-
-// ---------- small subcomponents ----------
-const radioRowStyle: React.CSSProperties = {
-  display: "flex",
-  alignItems: "center",
-  gap: 10,
-  padding: "8px 10px",
-  background: "#fff",
-  border: "1px solid #e5e7eb",
-  borderRadius: 10,
-  cursor: "pointer",
-};
-
-const radioOuterStyle: React.CSSProperties = {
-  width: 18,
-  height: 18,
-  borderRadius: "50%",
-  border: "1px solid #c7cdd6",
-  background: "#fff",
-  display: "grid",
-  placeItems: "center",
-};
-
-const radioDotStyle: React.CSSProperties = {
-  width: 10,
-  height: 10,
-  borderRadius: "50%",
-  background: "#111827",
-};
-
-type ComboWithChipsProps = {
-  label: string;
-  placeholder: string;
-  query: string;
-  setQuery: (v: string) => void;
-  options: { id: string; label: string }[];
-  selected: { id: string; label: string }[];
-  onAdd: (item: { id: string; label: string }) => void;
-  onRemove: (idx: number) => void;
-  stop: (e: React.SyntheticEvent) => void;
-  inputStyle: React.CSSProperties;
-  dropdownStyle: React.CSSProperties;
-  dropdownItem: React.CSSProperties;
-  chipStyle: React.CSSProperties;
-  chipsRowStyle: React.CSSProperties;
-};
-
-const ComboWithChips: React.FC<ComboWithChipsProps> = ({
-  label, placeholder, query, setQuery, options, selected, onAdd, onRemove, stop,
-  inputStyle, dropdownStyle, dropdownItem, chipStyle, chipsRowStyle,
-}) => {
-  const [open, setOpen] = React.useState(false);
-  return (
-    <div style={{ width: (inputStyle.width as number) || undefined }}>
-      <div style={{ fontSize: 12, color: "#4b5563", marginBottom: 4 }}>{label}</div>
-      <div style={{ display: "grid", gap: 8 }}>
-        <div style={chipsRowStyle}>
-          {selected.map((s, i) => (
-            <span key={s.id} style={chipStyle}>
-              {s.label}
-              <button
-                aria-label="Remove"
-                onMouseDown={stop}
-                onClick={() => onRemove(i)}
-                style={{ border: "none", background: "transparent", cursor: "pointer", color: "#6b7280" }}
-              >
-                ×
-              </button>
-            </span>
-          ))}
-        </div>
-        <div style={{ position: "relative" }}>
-          <input
-            value={query}
-            onChange={(e) => setQuery(e.target.value)}
-            onFocus={() => setOpen(true)}
-            onBlur={() => setTimeout(() => setOpen(false), 120)}
-            placeholder={placeholder}
-            onMouseDown={stop}
-            style={inputStyle}
-          />
-          {open && options.length > 0 && (
-            <div style={{ ...dropdownStyle, top: 40 }}>
-              {options.map((opt) => (
-                <div
-                  key={opt.id}
-                  style={dropdownItem}
-                  onMouseDown={stop}
-                  onClick={() => onAdd(opt)}
-                >
-                  {opt.label}
-                </div>
-              ))}
-            </div>
-          )}
-        </div>
-      </div>
-    </div>
-  );
-};
-
-type ComboCatsProps = {
-  label: string;
-  placeholder: string;
-  options: string[];
-  selected: string[];
-  onAdd: (item: string) => void;
-  onRemove: (idx: number) => void;
-  stop: (e: React.SyntheticEvent) => void;
-  inputStyle: React.CSSProperties;
-  dropdownStyle: React.CSSProperties;
-  dropdownItem: React.CSSProperties;
-  chipStyle: React.CSSProperties;
-  chipsRowStyle: React.CSSProperties;
-};
-
-const ComboCats: React.FC<ComboCatsProps> = ({
-  label, placeholder, options, selected, onAdd, onRemove, stop,
-  inputStyle, dropdownStyle, dropdownItem, chipStyle, chipsRowStyle,
-}) => {
-  const [q, setQ] = React.useState("");
-  const [open, setOpen] = React.useState(false);
-  const filtered = options.filter(o => o.toLowerCase().startsWith(q.toLowerCase()));
-  return (
-    <div style={{ width: (inputStyle.width as number) || undefined }}>
-      <div style={{ fontSize: 12, color: "#4b5563", marginBottom: 4 }}>{label}</div>
-      <div style={{ display: "grid", gap: 8 }}>
-        <div style={chipsRowStyle}>
-          {selected.map((s, i) => (
-            <span key={`${s}-${i}`} style={chipStyle}>
-              {s}
-              <button
-                aria-label="Remove"
-                onMouseDown={stop}
-                onClick={() => onRemove(i)}
-                style={{ border: "none", background: "transparent", cursor: "pointer", color: "#6b7280" }}
-              >
-                ×
-              </button>
-            </span>
-          ))}
-        </div>
-        <div style={{ position: "relative" }}>
-          <input
-            value={q}
-            onChange={(e) => setQ(e.target.value)}
-            onFocus={() => setOpen(true)}
-            onBlur={() => setTimeout(() => setOpen(false), 120)}
-            placeholder={placeholder}
-            onMouseDown={stop}
-            style={inputStyle}
-          />
-          {open && filtered.length > 0 && (
-            <div style={{ ...dropdownStyle, top: 40 }}>
-              {filtered.map((opt) => (
-                <div
-                  key={opt}
-                  style={dropdownItem}
-                  onMouseDown={stop}
-                  onClick={() => onAdd(opt)}
-                >
-                  {opt}
-                </div>
-              ))}
-            </div>
-          )}
-        </div>
-      </div>
-    </div>
-  );
-};
-
-type SingleComboProps = {
-  label: string;
-  placeholder: string;
-  query: string;
-  setQuery: (v: string) => void;
-  options: { id: string; label: string }[];
-  selected: { id: string; label: string } | null;
-  onSelect: (v: { id: string; label: string } | null) => void;
-  stop: (e: React.SyntheticEvent) => void;
-  inputStyle: React.CSSProperties;
-  dropdownStyle: React.CSSProperties;
-  dropdownItem: React.CSSProperties;
-  chipStyle: React.CSSProperties;
-  width: number;
-};
-
-const SingleCombo: React.FC<SingleComboProps> = ({
-  label, placeholder, query, setQuery, options, selected, onSelect, stop,
-  inputStyle, dropdownStyle, dropdownItem, chipStyle, width,
-}) => {
-  const [open, setOpen] = React.useState(false);
-  return (
-    <div style={{ width }}>
-      <div style={{ fontSize: 12, color: "#4b5563", marginBottom: 4 }}>{label}</div>
-      <div style={{ display: "grid", gap: 8 }}>
-        {selected && (
-          <span style={chipStyle}>
-            {selected.label}
-            <button
-              aria-label="Remove"
-              onMouseDown={stop}
-              onClick={() => onSelect(null)}
-              style={{ border: "none", background: "transparent", cursor: "pointer", color: "#6b7280" }}
-            >
-              ×
-            </button>
-          </span>
-        )}
-        <div style={{ position: "relative" }}>
-          <input
-            value={query}
-            onChange={(e) => setQuery(e.target.value)}
-            onFocus={() => setOpen(true)}
-            onBlur={() => setTimeout(() => setOpen(false), 120)}
-            placeholder={placeholder}
-            onMouseDown={stop}
-            style={inputStyle}
-          />
-          {open && options.length > 0 && (
-            <div style={{ ...dropdownStyle, top: 40 }}>
-              {options.map((opt) => (
-                <div
-                  key={opt.id}
-                  style={dropdownItem}
-                  onMouseDown={stop}
-                  onClick={() => onSelect(opt)}
-                >
-                  {opt.label}
-                </div>
-              ))}
-            </div>
-          )}
-        </div>
-      </div>
-    </div>
   );
 };

--- a/src/left-menu/MapViewControls.tsx
+++ b/src/left-menu/MapViewControls.tsx
@@ -1,0 +1,340 @@
+import * as React from "react";
+
+import {
+  FilterCombo,
+  CategoryCombo,
+  SingleCombo,
+  FilterComboOption,
+} from "./FilterCombo";
+
+type MapViewControlsProps = {
+  nodeOptions: FilterComboOption[];
+  categoryOptions: string[];
+  maxDepth: number;
+};
+
+export const MapViewControls: React.FC<MapViewControlsProps> = ({
+  nodeOptions,
+  categoryOptions,
+  maxDepth,
+}) => {
+  // local UI state (visual only)
+  const [expandMode, setExpandMode] = React.useState<"expand" | "collapse">(
+    "expand",
+  );
+  const [levelShown, setLevelShown] = React.useState<number>(
+    Math.min(3, Math.max(1, maxDepth)),
+  );
+  const [levelsOpen, setLevelsOpen] = React.useState(false);
+
+  const [showOnlyQuery, setShowOnlyQuery] = React.useState("");
+  const [excludeQuery, setExcludeQuery] = React.useState("");
+  const [centerQuery, setCenterQuery] = React.useState("");
+
+  const [showOnlySel, setShowOnlySel] = React.useState<FilterComboOption[]>([]);
+  const [excludeSel, setExcludeSel] = React.useState<FilterComboOption[]>([]);
+  const [categoryOnlySel, setCategoryOnlySel] = React.useState<string[]>([]);
+  const [categoryExcludeSel, setCategoryExcludeSel] = React.useState<string[]>([]);
+  const [centerSel, setCenterSel] = React.useState<FilterComboOption | null>(
+    null,
+  );
+
+  const stop = (e: React.SyntheticEvent) => e.stopPropagation();
+  const filteredNodes = (q: string) =>
+    nodeOptions.filter((o) =>
+      o.label.toLowerCase().startsWith(q.trim().toLowerCase()),
+    );
+  const filteredCats = (q: string) =>
+    categoryOptions.filter((c) =>
+      c.toLowerCase().startsWith(q.trim().toLowerCase()),
+    );
+  const addUnique = <T,>(
+    arr: T[],
+    item: T,
+    eq: (a: T, b: T) => boolean,
+  ) => (arr.find((x) => eq(x, item)) ? arr : [...arr, item]);
+  const removeAt = <T,>(arr: T[], index: number) =>
+    arr.filter((_, i) => i !== index);
+
+  const FIELD_W = 200; // compact width for Level + all filters below
+
+  const sectionTitle: React.CSSProperties = {
+    fontSize: 12,
+    fontWeight: 700,
+    color: "#374151",
+    textTransform: "uppercase",
+    letterSpacing: 0.4,
+    margin: "4px 0 8px",
+  };
+  const group: React.CSSProperties = { display: "grid", gap: 8 };
+  const labelStyle: React.CSSProperties = {
+    fontSize: 12,
+    color: "#4b5563",
+    marginBottom: 4,
+  };
+  const chip: React.CSSProperties = {
+    display: "inline-flex",
+    alignItems: "center",
+    gap: 6,
+    padding: "4px 8px",
+    background: "#fff",
+    border: "1px solid #e5e7eb",
+    borderRadius: 999,
+    fontSize: 12,
+    color: "#111827",
+  };
+  const inputNarrow: React.CSSProperties = {
+    width: FIELD_W,
+    height: 34,
+    padding: "0 10px",
+    borderRadius: 10,
+    border: "1px solid #e5e7eb",
+    background: "#ffffff",
+    outline: "none",
+    fontSize: 13,
+    color: "#111827",
+  };
+  const chipsRowNarrow: React.CSSProperties = {
+    display: "flex",
+    gap: 6,
+    flexWrap: "wrap",
+    maxWidth: FIELD_W,
+  };
+  const dropdownNarrow: React.CSSProperties = {
+    position: "absolute",
+    top: 6,
+    left: 0,
+    width: FIELD_W,
+    maxHeight: 160,
+    overflow: "auto",
+    background: "#fff",
+    border: "1px solid #e5e7eb",
+    borderRadius: 10,
+    boxShadow: "0 8px 20px rgba(0,0,0,0.08)",
+    zIndex: 30,
+  };
+  const dropdownItem: React.CSSProperties = {
+    padding: "8px 10px",
+    fontSize: 13,
+    color: "#111827",
+    cursor: "pointer",
+    borderBottom: "1px solid #f3f4f6",
+  };
+  const segWrap: React.CSSProperties = {
+    display: "grid",
+    gridTemplateColumns: "1fr 1fr",
+    gap: 8,
+  };
+  const segBtn = (active: boolean): React.CSSProperties => ({
+    height: 34,
+    borderRadius: 10,
+    border: "1px solid #e5e7eb",
+    background: active ? "#111827" : "#ffffff",
+    color: active ? "#ffffff" : "#111827",
+    fontSize: 13,
+    cursor: "pointer",
+  });
+  const selectBoxNarrow: React.CSSProperties = {
+    width: FIELD_W,
+    height: 34,
+    borderRadius: 10,
+    border: "1px solid #e5e7eb",
+    background: "#ffffff",
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "space-between",
+    padding: "0 10px",
+    fontSize: 13,
+    color: "#111827",
+    cursor: "pointer",
+  };
+  const resetBtn: React.CSSProperties = {
+    width: FIELD_W,
+    height: 36,
+    borderRadius: 12,
+    border: "1px solid #e5e7eb",
+    background: "#ffffff",
+    color: "#111827",
+    fontSize: 13,
+    fontWeight: 600,
+    cursor: "pointer",
+  };
+
+  return (
+    <div>
+      <div style={sectionTitle}>Map View</div>
+      <div style={group}>
+        {/* Expand / Collapse */}
+        <div>
+          <div style={labelStyle}>Expand</div>
+          <div style={{ ...segWrap, width: FIELD_W }}>
+            <button
+              style={segBtn(expandMode === "expand")}
+              onMouseDown={stop}
+              onClick={() => setExpandMode("expand")}
+            >
+              Expand all
+            </button>
+            <button
+              style={segBtn(expandMode === "collapse")}
+              onMouseDown={stop}
+              onClick={() => setExpandMode("collapse")}
+            >
+              Collapse all
+            </button>
+          </div>
+        </div>
+
+        {/* Show levels */}
+        <div>
+          <div style={labelStyle}>Show levels</div>
+          <div style={{ position: "relative", width: FIELD_W }}>
+            <div
+              style={selectBoxNarrow}
+              onMouseDown={stop}
+              onClick={() => setLevelsOpen((v) => !v)}
+            >
+              <span>Level {levelShown}</span>
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none">
+                <path
+                  d="M7 10l5 5 5-5"
+                  stroke="#6b7280"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+              </svg>
+            </div>
+            {levelsOpen && (
+              <div style={{ ...dropdownNarrow, top: 40 }}>
+                {Array.from({ length: Math.max(1, maxDepth) }, (_, i) => i + 1).map(
+                  (lvl) => (
+                    <div
+                      key={lvl}
+                      style={{
+                        ...dropdownItem,
+                        background: lvl === levelShown ? "#f3f4f6" : "#fff",
+                      }}
+                      onMouseDown={stop}
+                      onClick={() => {
+                        setLevelShown(lvl);
+                        setLevelsOpen(false);
+                      }}
+                    >
+                      Level {lvl}
+                    </div>
+                  ),
+                )}
+              </div>
+            )}
+          </div>
+        </div>
+
+        {/* Show only filter */}
+        <FilterCombo
+          label="Show only filter"
+          placeholder="Type to search nodes…"
+          query={showOnlyQuery}
+          setQuery={setShowOnlyQuery}
+          options={filteredNodes(showOnlyQuery)}
+          selected={showOnlySel}
+          onAdd={(item) =>
+            setShowOnlySel((prev) => addUnique(prev, item, (a, b) => a.id === b.id))
+          }
+          onRemove={(idx) =>
+            setShowOnlySel((prev) => removeAt(prev, idx))
+          }
+          stop={stop}
+          inputStyle={inputNarrow}
+          dropdownStyle={dropdownNarrow}
+          dropdownItem={dropdownItem}
+          chipStyle={chip}
+          chipsRowStyle={chipsRowNarrow}
+        />
+
+        {/* Exclude filter */}
+        <FilterCombo
+          label="Exclude filter"
+          placeholder="Type to search nodes…"
+          query={excludeQuery}
+          setQuery={setExcludeQuery}
+          options={filteredNodes(excludeQuery)}
+          selected={excludeSel}
+          onAdd={(item) =>
+            setExcludeSel((prev) => addUnique(prev, item, (a, b) => a.id === b.id))
+          }
+          onRemove={(idx) => setExcludeSel((prev) => removeAt(prev, idx))}
+          stop={stop}
+          inputStyle={inputNarrow}
+          dropdownStyle={dropdownNarrow}
+          dropdownItem={dropdownItem}
+          chipStyle={chip}
+          chipsRowStyle={chipsRowNarrow}
+        />
+
+        {/* Show only categories */}
+        <CategoryCombo
+          label="Show only categories"
+          placeholder="Type to search categories…"
+          options={filteredCats("")}
+          selected={categoryOnlySel}
+          onAdd={(item) =>
+            setCategoryOnlySel((prev) => addUnique(prev, item, (a, b) => a === b))
+          }
+          onRemove={(idx) =>
+            setCategoryOnlySel((prev) => removeAt(prev, idx))
+          }
+          stop={stop}
+          inputStyle={inputNarrow}
+          dropdownStyle={dropdownNarrow}
+          dropdownItem={dropdownItem}
+          chipStyle={chip}
+          chipsRowStyle={chipsRowNarrow}
+        />
+
+        {/* Exclude categories */}
+        <CategoryCombo
+          label="Exclude categories"
+          placeholder="Type to search categories…"
+          options={filteredCats("")}
+          selected={categoryExcludeSel}
+          onAdd={(item) =>
+            setCategoryExcludeSel((prev) => addUnique(prev, item, (a, b) => a === b))
+          }
+          onRemove={(idx) =>
+            setCategoryExcludeSel((prev) => removeAt(prev, idx))
+          }
+          stop={stop}
+          inputStyle={inputNarrow}
+          dropdownStyle={dropdownNarrow}
+          dropdownItem={dropdownItem}
+          chipStyle={chip}
+          chipsRowStyle={chipsRowNarrow}
+        />
+
+        {/* Center view */}
+        <SingleCombo
+          label="Center view"
+          placeholder="Type to search nodes…"
+          query={centerQuery}
+          setQuery={setCenterQuery}
+          options={filteredNodes(centerQuery)}
+          selected={centerSel}
+          onSelect={setCenterSel}
+          stop={stop}
+          inputStyle={inputNarrow}
+          dropdownStyle={dropdownNarrow}
+          dropdownItem={dropdownItem}
+          chipStyle={chip}
+          width={FIELD_W}
+        />
+
+        {/* Reset Layout */}
+        <button style={resetBtn} onMouseDown={stop}>
+          Reset Layout
+        </button>
+      </div>
+    </div>
+  );
+};
+


### PR DESCRIPTION
## Summary
- extract map view, layout, and filter combo logic into dedicated components
- re-export new subcomponents through LeftMenu while preserving external API

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: TypeScript errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68bc24fdbc68832a96089ae25e56c7b3